### PR TITLE
Allow to customize number of libzim workers

### DIFF
--- a/scraper/src/maps2zim/context.py
+++ b/scraper/src/maps2zim/context.py
@@ -111,6 +111,9 @@ class Context:
     # Geonames region to download (e.g. "allCountries", "FR", "US")
     geonames_region: str = "allCountries"
 
+    # Number of worker threads for the ZIM creator
+    zim_workers: int | None = None
+
     @classmethod
     def setup(cls, **kwargs: Any):
         new_instance = cls(**kwargs)

--- a/scraper/src/maps2zim/entrypoint.py
+++ b/scraper/src/maps2zim/entrypoint.py
@@ -205,6 +205,13 @@ def prepare_context(raw_args: list[str], tmpdir: str) -> None:
         dest="geonames_region",
     )
 
+    parser.add_argument(
+        "--zim-workers",
+        type=int,
+        help="Number of worker threads for the ZIM creator. Default: libzim default",
+        dest="zim_workers",
+    )
+
     args = parser.parse_args(raw_args)
 
     # Ignore unset values so they do not override the default specified in Context

--- a/scraper/src/maps2zim/processor.py
+++ b/scraper/src/maps2zim/processor.py
@@ -157,6 +157,8 @@ class Processor:
         logger.debug(f"User-Agent: {context.wm_user_agent}")
 
         creator = Creator(zim_path, "index.html")
+        if context.zim_workers is not None:
+            creator.config_nbworkers(context.zim_workers)
 
         logger.info("  Fetching ZIM illustration...")
         zim_illustration = self._fetch_zim_illustration()


### PR DESCRIPTION
This PR focus on allowing to customize number of libzim worker ; while probably not the ultimate solution to #38, it at least allows to workaround it until we've understood how to properly apply backpressure (see https://github.com/openzim/python-scraperlib/pull/282)