### PR TITLE
Add ScaleControl to the map for metric unit display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add map scale control (metric units) to display real-world distances at current zoom level (#46)
+
 ### Fixed
 
 - Use libzim 3.9.0 or above to fix freezing compression issues (#61)

--- a/zimui/main.js
+++ b/zimui/main.js
@@ -1,6 +1,6 @@
 import "./style.css";
 
-import { Map } from "maplibre-gl";
+import { Map, ScaleControl } from "maplibre-gl";
 import maplibre from "maplibre-gl";
 import axios from "axios";
 
@@ -140,6 +140,8 @@ const parseUrlFragment = () => {
       return { url: toAbsolute(url) };
     },
   });
+
+  map.addControl(new ScaleControl({ unit: "metric" }), "bottom-right");
 
   const setMapStyle = (styleName) => {
     map.setStyle(`./assets/${styleName}`, {


### PR DESCRIPTION
**What did:**
Added a persistent map length scale to the UI so users can always estimate real world distance at the current zoom level. fixes #46 

**What changed:**
Added MapLibre’s built-in ScaleControl to the map.
Placed the scale at the bottom-right so it stays visible at all times.
Kept the implementation minimal and focused (single JS change).