### PR TITLE
Set the maximum zoom level to 18 (20m/50ft) in map configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Set the maximum zoom level to 18 (#86)
 - Use libzim 3.9.0 or above to fix freezing compression issues (#61)
 - Immediately redirect when opening search results (#60)
 - Remove pin button with display of coordinates and zoom (#58)

--- a/zimui/main.js
+++ b/zimui/main.js
@@ -138,6 +138,7 @@ const parseUrlFragment = () => {
     container: "map",
     center: mapConfig.center,
     zoom: mapConfig.zoom,
+    maxZoom: 18,
     transformRequest: (url) => {
       return { url: toAbsolute(url) };
     },


### PR DESCRIPTION
Fixed issue #86 
Set the maximum zoom level to 18 (20m/50ft), as going further deep does not translate to better view

<img width="1375" height="585" alt="zoom-issue" src="https://github.com/user-attachments/assets/532dcd06-a063-407c-a697-82c1d784b052" />
