### PR TITLE
Move to a rectangular bounds approach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Create ZIM alias instead of redirects for tiles (#53)
 - Reduce number of alias for tiles to a strict minimum (#78)
 - Bundle ZIM UI inside pip package (#63)
+- Ensure map borders are consistent at all zoom levels (#90)
+- Homepage should focus on the proper location and zoom (#55)
 
 ## [0.1.1] - 2026-03-10
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,8 @@ Compile UI and copy.
 ```
 cd zimui
 yarn build
-cp -r dist/* ../extract
+cd ../extract
+cp -r ../scraper/src/maps2zim/zimui/* .
 cd ..
 ```
 

--- a/offliner-definition.json
+++ b/offliner-definition.json
@@ -13,7 +13,7 @@
       "type": "string",
       "required": false,
       "title": "Default View",
-      "description": "Default map view as latitude,longitude,zoom (e.g. 46.51,6.63,14 for Kiwix headquarters). Sets the initial center and zoom level of the map when UI loads."
+      "description": "Default map view as latitude,longitude,zoom (e.g. 46.51,6.63,14 for Kiwix headquarters). Sets the initial center and zoom level of the map when UI loads. zoom value is optional, you can pass only latitude,longitude (map will be zoomed out as much as possible)."
     },
     "name": {
       "type": "string",
@@ -83,14 +83,6 @@
       "required": false,
       "title": "Illustration URL",
       "description": "URL to illustration to use for ZIM illustration and favicon"
-    },
-    "include_up_to_zoom": {
-      "type": "integer",
-      "required": false,
-      "title": "Include Up To Zoom",
-      "description": "Include all tiles up to this zoom level, ignoring any poly filtering",
-      "min": 1,
-      "max": 14
     },
     "debug": {
       "type": "boolean",

--- a/scraper/src/maps2zim/context.py
+++ b/scraper/src/maps2zim/context.py
@@ -106,12 +106,8 @@ class Context:
     # Comma-separated URLs of .poly files defining regions to include tiles from
     include_poly_urls: str | None = None
 
-    # Include all tiles up to this zoom level, ignoring poly filtering
-    # Default is 6 (only 4096 tiles globally)
-    include_up_to_zoom: int | None = 6
-
     # Default map view: (latitude, longitude, zoom)
-    default_view: tuple[float, float, float] | None = None
+    default_view: tuple[float, float, float | None] | None = None
 
     # Geonames region to download (e.g. "allCountries", "FR", "US")
     geonames_region: str = "allCountries"

--- a/scraper/src/maps2zim/entrypoint.py
+++ b/scraper/src/maps2zim/entrypoint.py
@@ -16,26 +16,32 @@ from maps2zim.constants import (
 from maps2zim.context import MAPS_TMP, Context
 
 
-def parse_default_view(value: str) -> tuple[float, float, float]:
+def parse_default_view(value: str) -> tuple[float, float, float | None]:
     """Parse --default-view argument as latitude,longitude,zoom.
 
     Args:
-        value: comma-separated string of 3 floats
+        value: comma-separated string of 2 or 3 floats
 
     Returns:
         Tuple of (latitude, longitude, zoom) as floats
+        zoom can be None if not set
 
     Raises:
         argparse.ArgumentTypeError: if format is invalid
     """
     parts = value.split(",")
-    if len(parts) != 3:  # noqa: PLR2004
+    if len(parts) not in [2, 3]:
         raise argparse.ArgumentTypeError(
-            f"--default-view requires exactly 3 comma-separated values "
-            f"(latitude,longitude,zoom), got {len(parts)}"
+            "--default-view requires 2 or 3 comma-separated values "
+            "(latitude,longitude) or (latitude,longitude,zoom), got "
+            f"{len(parts)}"
         )
     try:
-        lat, lon, zoom = float(parts[0]), float(parts[1]), float(parts[2])
+        lat, lon, zoom = (
+            float(parts[0]),
+            float(parts[1]),
+            float(parts[2]) if len(parts) > 2 else None,  # noqa: PLR2004
+        )
     except ValueError:
         raise argparse.ArgumentTypeError(
             f"--default-view values must all be floats, got: {value!r}"
@@ -183,18 +189,12 @@ def prepare_context(raw_args: list[str], tmpdir: str) -> None:
     )
 
     parser.add_argument(
-        "--include_up_to_zoom",
-        type=int,
-        help="Include all tiles up to this zoom level, ignoring any poly filtering. "
-        f"Default: {Context.include_up_to_zoom}",
-        dest="include_up_to_zoom",
-    )
-
-    parser.add_argument(
         "--default-view",
         type=parse_default_view,
         help="Default map view as latitude,longitude,zoom (e.g. 43.731,7.416,12). "
-        "Sets the initial center and zoom level of the map when UI loads.",
+        "Sets the initial center and zoom level of the map when UI loads. zoom value "
+        "is optional, you can pass only latitude,longitude (map will be zoomed out as "
+        "much as possible).",
         dest="default_view",
     )
 

--- a/scraper/src/maps2zim/processor.py
+++ b/scraper/src/maps2zim/processor.py
@@ -94,15 +94,6 @@ class Processor:
     def _run_internal(self) -> Path:
         logger.setLevel(level=logging.DEBUG if context.debug else logging.INFO)
 
-        if (
-            context.area != "planet" or context.include_poly_urls
-        ) and not context.default_view:
-            logger.warning(
-                "You should pass --default-view arg when using a custom --area or "
-                "--include_poly_urls value(s), so that default map displayed in the UI "
-                "is nice."
-            )
-
         self.zim_config = ZimConfig(
             file_name=context.file_name,
             name=context.name,
@@ -225,6 +216,17 @@ class Processor:
 
         context.current_thread_workitem = "standard files"
 
+        # Initialize tile filter early so we can use the bounding box in config.json
+        tile_filter: TileFilter | None = None
+        if context.include_poly_urls:
+            context.current_thread_workitem = "loading poly files"
+            logger.info("  Downloading and loading .poly file(s) for filtering")
+            tile_filter = TileFilter(context.include_poly_urls)
+            logger.info(
+                f"  Loaded {tile_filter.polygon_count} polygon(s) for filtering"
+            )
+            context.current_thread_workitem = "standard files"
+
         logger.info("  Storing configuration...")
         creator.add_item_for(
             "content/config.json",
@@ -238,6 +240,14 @@ class Processor:
                     else None
                 ),
                 zoom=context.default_view[2] if context.default_view else None,
+                bounding_box=(
+                    [
+                        [tile_filter.bounding_box[0], tile_filter.bounding_box[1]],
+                        [tile_filter.bounding_box[2], tile_filter.bounding_box[3]],
+                    ]
+                    if tile_filter and tile_filter.bounding_box
+                    else None
+                ),
             ).model_dump_json(by_alias=True, exclude_none=True),
         )
 
@@ -306,36 +316,6 @@ class Processor:
 
         context.current_thread_workitem = "tilejson"
         self._write_tilejson(creator)
-
-        # Initialize tile filter if poly files or zoom filtering is specified
-        tile_filter: TileFilter | None = None
-        if context.include_poly_urls or context.include_up_to_zoom is not None:
-            context.current_thread_workitem = "loading poly files"
-
-            # Validate include_up_to_zoom if specified
-            if context.include_up_to_zoom is not None:
-                max_zoom = self._get_mbtiles_maxzoom()
-                if context.include_up_to_zoom >= max_zoom:
-                    raise ValueError(
-                        f"--include_up_to_zoom ({context.include_up_to_zoom}) "
-                        f"must be less than the maximum zoom in mbtiles ({max_zoom})"
-                    )
-
-            if context.include_poly_urls:
-                logger.info("  Downloading and loading .poly file(s) for filtering")
-            tile_filter = TileFilter(
-                context.include_poly_urls or "",
-                max_zoom_no_filter=context.include_up_to_zoom,
-            )
-            if context.include_poly_urls:
-                logger.info(
-                    f"  Loaded {tile_filter.polygon_count} polygon(s) for filtering"
-                )
-            if context.include_up_to_zoom is not None:
-                logger.info(
-                    f"  Including all tiles up to zoom "
-                    f"level {context.include_up_to_zoom}"
-                )
 
         context.current_thread_workitem = "download places data"
         self._fetch_geonames_zip()

--- a/scraper/src/maps2zim/tile_filter.py
+++ b/scraper/src/maps2zim/tile_filter.py
@@ -3,7 +3,7 @@
 import math
 from pathlib import Path
 
-from shapely.geometry import Point, Polygon
+from shapely.geometry import Polygon
 from shapely.ops import unary_union
 from zimscraperlib.download import save_large_file
 
@@ -33,6 +33,8 @@ def download_poly_file(url: str, dest_folder: Path) -> Path:
         filename = f"{filename}.poly"
 
     filepath = dest_folder / filename
+    if filepath.exists():
+        return filepath
 
     logger.debug(f"Downloading .poly file from {url}")
     save_large_file(url, fpath=filepath)
@@ -147,54 +149,58 @@ def tile_to_bbox(z: int, x: int, y: int) -> tuple[float, float, float, float]:
 
 
 class TileFilter:
-    """Filter tiles based on geographic regions from .poly files."""
+    """Filter tiles based on the bounding box of geographic regions from .poly files."""
 
-    def __init__(self, poly_urls: str, max_zoom_no_filter: int | None = None) -> None:
+    def __init__(self, poly_urls: str) -> None:
         """Initialize TileFilter from comma-separated .poly file URLs.
+
+        Computes the bounding box of all polygons and uses it for filtering.
 
         Args:
             poly_urls: Comma-separated URLs of .poly files to download and use
-            max_zoom_no_filter: Include all tiles up to this zoom level,
-                ignoring poly filtering. None means filter all zooms.
 
         Raises:
             ValueError: If no valid polygons are found
         """
-        self.polygons: list[Polygon] = []
-        self.unified_geometry: Polygon | None = None
         self.polygon_count = 0
-        self.max_zoom_no_filter = max_zoom_no_filter
+        # (min_lon, min_lat, max_lon, max_lat) or None if no filtering
+        self.bounding_box: tuple[float, float, float, float] | None = None
 
         if not poly_urls or not poly_urls.strip():
             return
 
         # Parse comma-separated URLs
         urls = [url.strip() for url in poly_urls.split(",")]
+        polygons: list[Polygon] = []
 
         # Download and parse each .poly file
         for url in urls:
             try:
                 poly_path = download_poly_file(url, context.tmp_folder)
                 polygon = parse_poly_file(poly_path)
-                self.polygons.append(polygon)
+                polygons.append(polygon)
                 logger.debug(f"Loaded polygon from {url}")
             except Exception as e:
                 logger.error(f"Failed to load .poly file from {url}: {e}")
                 raise
 
-        if self.polygons:
-            # Union all polygons into a single geometry for efficient
-            # intersection checks
-            if len(self.polygons) == 1:
-                self.unified_geometry = self.polygons[0]
+        if polygons:
+            if len(polygons) == 1:
+                unified = polygons[0]
             else:
-                self.unified_geometry = unary_union(self.polygons)  # type: ignore
-            self.polygon_count = len(self.polygons)
+                unified = unary_union(polygons)  # type: ignore
+            self.polygon_count = len(polygons)
 
-            logger.info(f"Loaded {self.polygon_count} polygon(s) for filtering")
+            min_lon, min_lat, max_lon, max_lat = unified.bounds
+            self.bounding_box = (min_lon, min_lat, max_lon, max_lat)
+
+            logger.info(
+                f"Loaded {self.polygon_count} polygon(s) for filtering, "
+                f"bounding box: {self.bounding_box}"
+            )
 
     def tile_intersects(self, z: int, x: int, y: int) -> bool:
-        """Check if a tile intersects with any of the loaded polygon regions.
+        """Check if a tile intersects with the bounding box of the loaded regions.
 
         Args:
             z: Zoom level
@@ -204,40 +210,28 @@ class TileFilter:
         Returns:
             True if tile should be included, False otherwise
         """
-        # Check if this zoom level should be included without filtering
-        if self.max_zoom_no_filter is not None and z <= self.max_zoom_no_filter:
+        if self.bounding_box is None:
             return True
 
-        # If no polygon filtering is active, include the tile
-        if self.unified_geometry is None:
-            return True
-
-        # Get tile bounding box
         west, south, east, north = tile_to_bbox(z, x, y)
+        min_lon, min_lat, max_lon, max_lat = self.bounding_box
 
-        # Create a box from the tile bounds
-        tile_box = Polygon(
-            [
-                (west, south),
-                (east, south),
-                (east, north),
-                (west, north),
-            ]
+        # Check if tile bbox overlaps with region bounding box
+        return not (
+            east < min_lon or west > max_lon or north < min_lat or south > max_lat
         )
 
-        # Check if tile intersects with any region
-        return tile_box.intersects(self.unified_geometry)
-
     def contains_point(self, lon: float, lat: float) -> bool:
-        """Check if a geographic point is within the loaded polygon regions.
+        """Check if a geographic point is within the bounding box of loaded regions.
 
         Args:
             lon: Longitude in degrees
             lat: Latitude in degrees
 
         Returns:
-            True if point is inside any region, or if no filtering is active.
+            True if point is inside the bounding box, or if no filtering is active.
         """
-        if self.unified_geometry is None:
+        if self.bounding_box is None:
             return True
-        return self.unified_geometry.contains(Point(lon, lat))
+        min_lon, min_lat, max_lon, max_lat = self.bounding_box
+        return min_lon <= lon <= max_lon and min_lat <= lat <= max_lat

--- a/scraper/src/maps2zim/ui.py
+++ b/scraper/src/maps2zim/ui.py
@@ -13,3 +13,5 @@ class ConfigModel(CamelModel):
     zim_name: str | None = None
     center: list[float] | None = None
     zoom: float | None = None
+    # [[min_lon, min_lat], [max_lon, max_lat]]
+    bounding_box: list[list[float]] | None = None

--- a/scraper/tests/test_processor.py
+++ b/scraper/tests/test_processor.py
@@ -416,7 +416,8 @@ def test_parse_geonames_with_tile_filter():
             )
 
             tile_filter = TileFilter("")  # Create empty filter
-            tile_filter.unified_geometry = lyon_polygon
+            min_lon, min_lat, max_lon, max_lat = lyon_polygon.bounds
+            tile_filter.bounding_box = (min_lon, min_lat, max_lon, max_lat)
             tile_filter.polygon_count = 1
 
             # Create processor and parse geonames with filter

--- a/scraper/tests/test_tile_filter.py
+++ b/scraper/tests/test_tile_filter.py
@@ -125,23 +125,17 @@ def test_parse_poly_file_empty():
             parse_poly_file(poly_path)
 
 
-def test_tile_filter_zoom_no_filter():
-    """Test that tiles at or below max_zoom_no_filter are always included."""
-    # Create filter with max_zoom_no_filter=5
-    tile_filter = TileFilter("", max_zoom_no_filter=5)
+def test_tile_filter_no_filter():
+    """Test that a filter with no poly URLs includes all tiles."""
+    tile_filter = TileFilter("")
 
-    # Tiles at zoom 0-5 should be included
     assert tile_filter.tile_intersects(0, 0, 0) is True
-    assert tile_filter.tile_intersects(3, 2, 4) is True
-    assert tile_filter.tile_intersects(5, 10, 20) is True
-
-    # Tiles at zoom > 5 should also be included (no poly filtering)
-    assert tile_filter.tile_intersects(6, 30, 40) is True
     assert tile_filter.tile_intersects(10, 500, 500) is True
+    assert tile_filter.bounding_box is None
 
 
-def test_tile_filter_zoom_no_filter_with_poly():
-    """Test zoom filtering with polygon filtering."""
+def test_tile_filter_bounding_box():
+    """Test tile filtering based on bounding box derived from poly."""
     poly_content = """test_area
 test_polygon
     0.0    0.0
@@ -157,26 +151,21 @@ END
         poly_path = Path(tmpdir) / "test.poly"
         poly_path.write_text(poly_content)
 
-        # Mock the TileFilter by directly setting up the geometry
-        tile_filter = TileFilter("", max_zoom_no_filter=5)
+        tile_filter = TileFilter("")
         polygon = parse_poly_file(poly_path)
-        tile_filter.unified_geometry = polygon
+        min_lon, min_lat, max_lon, max_lat = polygon.bounds
+        tile_filter.bounding_box = (min_lon, min_lat, max_lon, max_lat)
         tile_filter.polygon_count = 1
 
-        # Tiles at zoom 0-5 should be included regardless of poly
-        assert tile_filter.tile_intersects(0, 0, 0) is True
-        assert tile_filter.tile_intersects(5, 5, 5) is True
-
-        # Tiles at zoom > 5 should be filtered by polygon
-        # Tile at zoom 10, column 512, row 512 is approximately at (0, 0)
-        # which should be inside the poly
-        assert tile_filter.tile_intersects(10, 512, 512) is True
-        # Tile far away should not intersect
+        # Bounding box is (0, 0, 1, 1) — tiles overlapping this region should pass
+        # Tile at zoom 10, ~(0,0) should intersect
+        assert tile_filter.tile_intersects(10, 512, 511) is True
+        # Tile far away (top-left of world) should not intersect
         assert tile_filter.tile_intersects(10, 0, 0) is False
 
 
 def test_tile_filter_contains_point():
-    """Test point-in-polygon filtering."""
+    """Test point-in-bounding-box filtering."""
     poly_content = """test_area
 test_polygon
     0.0    0.0
@@ -192,25 +181,25 @@ END
         poly_path = Path(tmpdir) / "test.poly"
         poly_path.write_text(poly_content)
 
-        # Create filter and inject polygon (avoid downloading)
         tile_filter = TileFilter("")
         polygon = parse_poly_file(poly_path)
-        tile_filter.unified_geometry = polygon
+        min_lon, min_lat, max_lon, max_lat = polygon.bounds
+        tile_filter.bounding_box = (min_lon, min_lat, max_lon, max_lat)
         tile_filter.polygon_count = 1
 
-        # Test points inside the polygon
+        # Points inside the bounding box
         assert tile_filter.contains_point(0.5, 0.5) is True
         assert tile_filter.contains_point(0.25, 0.75) is True
         assert tile_filter.contains_point(0.1, 0.1) is True
 
-        # Test points outside the polygon
+        # Points outside the bounding box
         assert tile_filter.contains_point(-0.5, 0.5) is False
         assert tile_filter.contains_point(1.5, 0.5) is False
         assert tile_filter.contains_point(0.5, -0.5) is False
         assert tile_filter.contains_point(2.0, 2.0) is False
 
-        # Test with no geometry set (should always return True)
-        tile_filter_no_geo = TileFilter("")
-        assert tile_filter_no_geo.contains_point(0.5, 0.5) is True
-        assert tile_filter_no_geo.contains_point(-180.0, -90.0) is True
-        assert tile_filter_no_geo.contains_point(180.0, 90.0) is True
+        # Test with no bounding box (should always return True)
+        tile_filter_no_bounds = TileFilter("")
+        assert tile_filter_no_bounds.contains_point(0.5, 0.5) is True
+        assert tile_filter_no_bounds.contains_point(-180.0, -90.0) is True
+        assert tile_filter_no_bounds.contains_point(180.0, 90.0) is True

--- a/zimui/main.js
+++ b/zimui/main.js
@@ -75,10 +75,9 @@ const parseUrlFragment = () => {
 
 // Load config and initialize map
 (async () => {
-  let mapConfig = { center: [0, 0], zoom: 0 };
-  let defaultCenter = [0, 0];
-  let defaultZoom = 0;
-  let hasConfigDefaults = false;
+  let defaultCenter = undefined;
+  let defaultZoom = undefined;
+  let mapConfig = { center: undefined, zoom: undefined, bounds: undefined };
   let zimName = null;
   let storageKey = null;
 
@@ -98,11 +97,12 @@ const parseUrlFragment = () => {
     // Store default center and zoom from config
     if (config.center) {
       defaultCenter = config.center;
-      hasConfigDefaults = true;
     }
     if (config.zoom !== undefined) {
       defaultZoom = config.zoom;
-      hasConfigDefaults = true;
+    }
+    if (config.boundingBox) {
+      mapConfig.bounds = config.boundingBox;
     }
 
     // Check for URL fragment parameters (highest priority)
@@ -121,7 +121,7 @@ const parseUrlFragment = () => {
         }
       }
 
-      // Use saved view if available, otherwise use config values
+      // Use saved view if available, otherwise use default values
       if (savedView && savedView.center && savedView.zoom !== undefined) {
         mapConfig.center = savedView.center;
         mapConfig.zoom = savedView.zoom;
@@ -136,13 +136,29 @@ const parseUrlFragment = () => {
 
   const map = new Map({
     container: "map",
-    center: mapConfig.center,
-    zoom: mapConfig.zoom,
     maxZoom: 18,
     transformRequest: (url) => {
       return { url: toAbsolute(url) };
     },
   });
+
+  window.__openzim_map = map; // Save in window, useful for debug purposes
+
+  if (mapConfig.bounds !== undefined) {
+    console.log(`Setting bounds to ${mapConfig.bounds}`);
+    map.setMaxBounds(mapConfig.bounds);
+  }
+
+  if (mapConfig.zoom !== undefined) {
+    console.log(`Setting zoom to ${mapConfig.zoom}`);
+    map.setZoom(mapConfig.zoom);
+  }
+
+  if (mapConfig.center !== undefined) {
+    console.log(`Setting center to ${mapConfig.center}`);
+    map.setCenter(mapConfig.center);
+  }
+
   const scale = new ScaleControl({ unit: "metric" });
   map.addControl(scale, "bottom-right");
 
@@ -204,7 +220,7 @@ const parseUrlFragment = () => {
   // Show button container and reset button only after map loads if config has defaults
   map.on("load", () => {
     buttonContainer.classList.add("visible");
-    if (hasConfigDefaults) {
+    if (defaultCenter !== undefined) {
       resetButton.style.display = "flex";
     }
   });
@@ -222,15 +238,63 @@ const parseUrlFragment = () => {
 
   // Reset button functionality
   resetButton.addEventListener("click", () => {
-    map.flyTo({
-      center: defaultCenter,
-      zoom: defaultZoom,
-      duration: 1000,
-    });
+    if (defaultCenter !== undefined) {
+      if (defaultZoom !== undefined) {
+        map.flyTo({
+          center: defaultCenter,
+          zoom: defaultZoom,
+          duration: 1000,
+        });
+      } else {
+        // zoom-out as much as possible while keeping expected center
+        map.fitBounds(map.getMaxBounds(), {
+          center: defaultCenter,
+          duration: 1000,
+        });
+      }
+    }
   });
 
   // About button functionality
   aboutButton.addEventListener("click", () => {
     window.location.href = toAbsolute("./content/about.html");
   });
+
+  // Debounce function for updating coordinates
+  const debounce = (func, wait) => {
+    let timeout;
+    return function executedFunction(...args) {
+      const later = () => {
+        window.clearTimeout(timeout);
+        func(...args);
+      };
+      window.clearTimeout(timeout);
+      timeout = window.setTimeout(later, wait);
+    };
+  };
+
+  // Update coordinates display and save view to localStorage
+  const updateCoordinates = () => {
+    const center = map.getCenter();
+
+    // Save current view to localStorage if we have a storage key
+    if (storageKey) {
+      try {
+        const view = {
+          center: [center.lng, center.lat],
+          zoom: map.getZoom(),
+        };
+        window.localStorage.setItem(storageKey, JSON.stringify(view));
+      } catch (e) {
+        console.warn("Could not save view to localStorage:", e);
+      }
+    }
+  };
+
+  // Debounced update function (100ms delay)
+  const debouncedUpdateCoordinates = debounce(updateCoordinates, 100);
+
+  // Listen to map move and zoom events
+  map.on("move", debouncedUpdateCoordinates);
+  map.on("zoom", debouncedUpdateCoordinates);
 })();


### PR DESCRIPTION
Fix #55 
Fix #90 

Changes:
- compute the bounding box of the poly, and fetch all tiles in this box (and nothing more):
  - display only this box in the map, not possible to zoom out / move out
  - no more black areas on the screen
  - drop the `--include_up_to_zoom` parameter
- always find optimal initial zoom based on bounding box + current viewport size
- add support for passing only lat/lon in `--default-view` so that zoom is automatically computed
- fix storage of last known position which was broken by #67 
- fix `CONTRIBUTING.md` which was broken by #88